### PR TITLE
Bug fix/pending trip cards

### DIFF
--- a/src/Traveler.js
+++ b/src/Traveler.js
@@ -31,8 +31,7 @@ class Traveler {
   };
 
   listPendingTrips() {
-    let tripsPending = this.allTrips.filter(trip => trip.status === 'pending')
-    this.pendingTrips = tripsPending;
+    this.pendingTrips = this.allTrips.filter(trip => trip.status === 'pending')
     return this.pendingTrips;
   };
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -81,17 +81,6 @@ const renderData = (id) => {
   .catch((error) => console.log(`There has been an error! ${error}`));
 };
 
-export const updateData = () => {
-  getAll()
-  .then(data => {
-    clearFormInput();
-    getTripsRepo(data[2]);
-    getTravelerTrips(data[2]);
-    generatePendingGrid();
-  })
-  .catch((error) => console.log(`There has been an error! ${error}`));
-};
-
 const createTraveler = (travelersData, id) => {
   travelers = travelersData.travelers.map(traveler => new Traveler(traveler));
   currentTraveler = travelers[id - 1];
@@ -106,6 +95,7 @@ const getTripsRepo = (tripsData) => {
 };
 
 const getTravelerTrips = (tripsData) => {
+  currentTraveler.allTrips = [];
   currentTraveler.listAllTrips(tripsData.trips);
   currentTraveler.allTrips.sort((a, b) => {
     return new Date(b.date) - new Date(a.date);
@@ -187,6 +177,7 @@ const generateFutureGrid = () => {
 };
 
 const generatePendingGrid = () => {
+  pendingGrid.innerHTML = '';
   currentTraveler.listPendingTrips().forEach(trip => {
     pendingGrid.innerHTML +=
     `<article class='card'>
@@ -231,6 +222,17 @@ const createFormTripObj = () => {
   } else {
     messageBox.innerText = 'Please fill in all boxes.'
   }
+};
+
+export const updateData = () => {
+  getAll()
+  .then(data => {
+    clearFormInput();
+    getTripsRepo(data[2]);
+    getTravelerTrips(data[2]);
+    generatePendingGrid();
+  })
+  .catch((error) => console.log(`There has been an error! ${error}`));
 };
 
 const clearFormInput = () => {


### PR DESCRIPTION
This PR addresses a bug in the pending trip cards where after the POST request, the previously existing pending trips would duplicate 2 or 3 times, but the new pending trip posted as one card. After re-logging in, though, the pending trips would display properly with all the trips.

To fix this, on scripts.js line 98, the current traveler's trips array was emptied before running the proper functions. On scripts.js line 180, the pending trips grid was emptied of all cards before refilling with cards.

Closes issue #14 